### PR TITLE
Update me5e.js: removing the reference to cooking utensils as a tool in the module

### DIFF
--- a/src/me5e.js
+++ b/src/me5e.js
@@ -85,7 +85,6 @@ DND5E.toolProficiencies["herb"] = "Chemist's Supplies";
 DND5E.toolProficiencies["navg"] = "Starship System (Navigation)";
 DND5E.toolProficiencies["pois"] = "Brewer's Supplies"
 DND5E.toolProficiencies["aswb"] = "Armorsmith's Workbench";
-DND5E.toolProficiencies["cook"] = "Cook's Utensils";
 DND5E.toolProficiencies["h4ck"] = "Hacking Tools";
 DND5E.toolProficiencies["mdcn"] = "Medical Kit";
 DND5E.toolProficiencies["pntr"] = "Painter's Supplies";


### PR DESCRIPTION
The issue is caused by the module creating a new reference to cooking utensils in the game. Cooking utensils is found under artisan tools in the core dnd5e game system so there is no need to have this in the module. 